### PR TITLE
🐛 Correct Threshold Censor Regressor syntax

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
 
   build-macos:
     macos:
-      xcode: "10.0.0"
+      xcode: "13.0.0"
     environment:
       FL_OUTPUT_DIR: output
     steps:


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #114 by @shnizzedy

## Description
<!-- Concisely describe what the pull request does. -->
Updates the Regressor component to:
* [x] change the thresholds key under `Censor` from `threshold` to `thresholds`
* [x] make the thresholds lists of dictionaries instead of dictionaries
* [x] include censor details in shorthand displayed in GUI

While testing this change, I noticed that some fields aren't included in the generated YAML if they aren't changed from the default. That's not typically an issue since C-PAC will use values from the default pipeline if the values aren't populated, but, for example, the default pipeline doesn't have any values for a custom regressor, so we should

- https://github.com/FCP-INDI/C-PAC_GUI/issues/116

## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete the section entirely. -->
Try to make a regressor with censoring at https://fcp-indi.github.io/C-PAC_GUI/versions/nightly/browser and in this branch locally (https://github.com/FCP-INDI/C-PAC_GUI/blob/0c942fb526c4b053dfcc2f958fe0ba4f03697450/README.md#L8-L10) and see the difference.

Here are the relevant sections of the YAML files generated during the screen captures below:

### before

```YAML
      - Name: scrub
        Censor:
          threshold:
            type: FD_P
            value: '0.2'
          number_of_previous_trs_to_censor: '3'
          number_of_subsequent_trs_to_censor: '3'
```

### after

```YAML
      - Name: scrub
        Censor:
          number_of_previous_trs_to_censor: '3'
          number_of_subsequent_trs_to_censor: '3'
          thresholds:
            - type: FD_P
              value: '0.2'
```

## Screencaps
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->

https://user-images.githubusercontent.com/5974438/133334218-b8562287-d072-459f-b73d-eb9543cfe21c.mp4

https://user-images.githubusercontent.com/5974438/133334264-8c442081-c9a6-49b6-8c55-82c2f92fd399.mp4

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
