### PR TITLE
🐛 Strip '.dev' before checking semver

### DIFF
--- a/app/components/PipelineCard.jsx
+++ b/app/components/PipelineCard.jsx
@@ -1,20 +1,16 @@
 import React, { Component } from 'react';
-import { connect } from 'react-redux';
-import { withRouter, Link } from 'react-router-dom';
+import { withRouter } from 'react-router-dom';
 import Immutable from 'immutable';
 import PropTypes from 'prop-types';
 import semver from 'semver';
 
-import clsx from 'clsx'
-import { formatMs, withStyles } from '@material-ui/core/styles';
+import { withStyles } from '@material-ui/core/styles';
 
 import { Map } from 'immutable';
 
-import Grid from '@material-ui/core/Grid';
 
 import Card from '@material-ui/core/Card';
 import CardHeader from '@material-ui/core/CardHeader';
-import CardMedia from '@material-ui/core/CardMedia';
 import CardContent from '@material-ui/core/CardContent';
 import CardActions from '@material-ui/core/CardActions';
 
@@ -22,28 +18,14 @@ import List from '@material-ui/core/List';
 import ListItem from '@material-ui/core/ListItem';
 import ListItemIcon from '@material-ui/core/ListItemIcon';
 import ListItemText from '@material-ui/core/ListItemText';
-import ListItemSecondaryAction from '@material-ui/core/ListItemSecondaryAction';
-
-import Typography from '@material-ui/core/Typography';
 import Avatar from '@material-ui/core/Avatar';
 import IconButton from '@material-ui/core/IconButton';
-import Button from '@material-ui/core/Button';
 import Tooltip from '@material-ui/core/Tooltip';
 
 import {
-  EnvironmentIcon,
   PipelineIcon,
-  PipelineStepIcon,
-  PipelineExecutionTimeIcon,
-  SubjectIcon,
-  RunIcon,
-  LaunchIcon,
-  SettingsIcon,
   NavigateNextIcon,
   PlayArrowIcon,
-  TimerIcon,
-  LogIcon,
-  BrainIcon,
   DeleteIcon,
   DeprecatedIcon,
   DownloadIcon,
@@ -51,12 +33,18 @@ import {
 } from './icons';
 import { formatLabel } from '../containers/pipeline/parts/PipelinePart';
 import { isADefault } from '../containers/PipelinePage';
+import PipelineStep from './PipelineStep';
 
 import cpac from '@internal/c-pac';
 
 const cardSteps = ['anatomical_preproc', 'functional_preproc', 'surface_analysis'];
 
-/** A card component to show a pipeline configuration available to view/edit, duplicate, and/or delete. */
+function stripDevSuffix(version) {
+  return version.endsWith('.dev') ? version.slice(0, -4) : version;
+}
+
+/** A card component to show a pipeline configuration available to view/edit, duplicate, and/or
+ * delete. */
 class PipelineCard extends Component {
   static propTypes = {
     /** Inherited style */
@@ -100,36 +88,36 @@ class PipelineCard extends Component {
     const configuration = pipeline.getIn(['versions', version, 'configuration']);
     const cpacVersion = pipeline.getIn(['versions', version, 'version']);
 
-    var blob = new Blob(
+    const blob = new Blob(
       [cpac.pipeline.dump(
         configuration.toJS(), pipelineName, version, cpacVersion
       )],
-      { type: "text/yaml;charset=utf-8" }
+      { type: 'text/yaml;charset=utf-8' }
     );
 
-    var anchor = document.createElement('a');
+    const anchor = document.createElement('a');
     anchor.href = window.URL.createObjectURL(blob);
     anchor.target = '_blank';
-    anchor.download = pipelineName + '.yml'
+    anchor.download = `${pipelineName}.yml`;
     anchor.click();
   }
 
   handleOpen = (pipeline) => {
-    this.props.history.push(`/pipelines/${pipeline}`)
+    this.props.history.push(`/pipelines/${pipeline}`);
   }
 
   render() {
-    const { classes, pipeline } = this.props
+    const { classes, pipeline } = this.props;
 
     const pipelineIsADefault = isADefault(pipeline.get('id'));
-    let versionId = '0'
-    const versions = pipeline.get('versions')
-    if (!versions.has("0")) {
-      versionId = versions.keySeq().max()
+    let versionId = '0';
+    const versions = pipeline.get('versions');
+    if (!versions.has('0')) {
+      versionId = versions.keySeq().max();
     }
 
-    const version = versions.get(versionId)
-    const configuration = version.getIn(['configuration', ]);
+    const version = versions.get(versionId);
+    const configuration = version.getIn(['configuration']);
 
     let derivatives = [];
     Object.keys(configuration.toJS()).forEach(step => {
@@ -138,15 +126,15 @@ class PipelineCard extends Component {
       } else {
         const tabStep = configuration.getIn([step]);
         if (Map.isMap(tabStep)) {
-          let [...stepKeys] = tabStep.keys();
+          const [...stepKeys] = tabStep.keys();
           if (stepKeys.includes('run')) {
             const runswitch = configuration.getIn([step, 'run']);
             if (
-              !cardSteps.includes(step) &&
-              runswitch &&
-              (
-                typeof(runswitch) === 'boolean' ||
-                (Array.isArray(runswitch) && runswitch.includes(true))
+              !cardSteps.includes(step)
+              && runswitch
+              && (
+                typeof runswitch === 'boolean'
+                || (Array.isArray(runswitch) && runswitch.includes(true))
               )
             ) { derivatives.push(step); }
           }
@@ -154,43 +142,43 @@ class PipelineCard extends Component {
           console.warn(`Tab "${step}" seems to be malformed in pipeline "${pipeline.get('name')}"`);
         }
       }
-    })
+    });
     derivatives = Array.from(derivatives);
     derivatives = derivatives ? derivatives.length : 0;
     let cardSubheader = `C-PAC ${version.get('version')}`;
-    if (configuration.hasOwnProperty('importedPipeline')) {
-      cardSubheader = `FROM '${configuration.importedPipeline}' (${cardSubheader})`
+    if (Object.prototype.hasOwnProperty.call(configuration, 'importedPipeline')) {
+      cardSubheader = `FROM '${configuration.importedPipeline}' (${cardSubheader})`;
     }
-    if (semver.gte(version.get('version'), '1.8.0')) {
+    if (semver.gte(stripDevSuffix(version.get('version')), '1.8.0')) {
       return (
         <Card className={classes.card}>
           <CardHeader
-            avatar={
+            avatar={(
               <Avatar className={classes.avatar}>
                 <PipelineIcon />
               </Avatar>
-            }
+            )}
             title={pipeline.get('name')}
             subheader={cardSubheader}
           />
           <CardContent className={classes.info}>
             <List>
-              {cardSteps.map(step =>{
+              {cardSteps.map(step => {
                 const runKey = 'run';
                 return (
                   <PipelineStep
-                    {...{classes}}
+                    {...{ classes }}
                     stepKey={configuration.getIn([step, runKey], true)}
                     label={formatLabel(step)}
                     key={step}
                   />
-                )
+                );
               })}
               <PipelineStep
-                {...{classes}}
+                {...{ classes }}
                 stepKey={Boolean(derivatives)}
                 label={`${derivatives} derivative${derivatives === 1 ? '' : 's'}`}
-                key='derivatives'
+                key="derivatives"
               />
             </List>
           </CardContent>
@@ -202,14 +190,13 @@ class PipelineCard extends Component {
               </IconButton>
             </Tooltip>
 
-            { !pipelineIsADefault ?
+            { !pipelineIsADefault ? (
               <Tooltip title="Delete">
                 <IconButton onClick={() => this.props.onDelete(pipeline.get('id'))}>
                   <DeleteIcon />
                 </IconButton>
               </Tooltip>
-              : null
-            }
+            ) : null }
 
             <Tooltip title={pipelineIsADefault ? 'View' : 'View / Edit'}>
               <IconButton className={classes.expand} onClick={() => this.handleOpen(pipeline.get('id'))}>
@@ -218,72 +205,46 @@ class PipelineCard extends Component {
             </Tooltip>
           </CardActions>
         </Card>
-      )
-    } else {
-      return (
-        <Card className={classes.card}>
-          <CardHeader
-            avatar={
-              <Avatar className={classes.avatar}>
-                <PipelineIcon />
-              </Avatar>
-            }
-            title={pipeline.get('name')}
-            subheader={cardSubheader}
-          />
-          <CardContent className={classes.info}>
+      );
+    }
+    return (
+      <Card className={classes.card}>
+        <CardHeader
+          avatar={(
+            <Avatar className={classes.avatar}>
+              <PipelineIcon />
+            </Avatar>
+          )}
+          title={pipeline.get('name')}
+          subheader={cardSubheader}
+        />
+        <CardContent className={classes.info}>
           <List>
-            <ListItem key='deprecated'>
+            <ListItem key="deprecated">
               <ListItemIcon>
                 <DeprecatedIcon />
               </ListItemIcon>
-              <ListItemText primary='Deprecated' secondary='Please upgrade your pipeline configuration' />
+              <ListItemText primary="Deprecated" secondary="Please upgrade your pipeline configuration" />
             </ListItem>
           </List>
-          </CardContent>
-          <CardActions className={classes.actions}>
+        </CardContent>
+        <CardActions className={classes.actions}>
 
-            <Tooltip title="Download config file">
-              <IconButton onClick={() => this.handleDownload(pipeline.get('id'))}>
-                <DownloadIcon />
-              </IconButton>
-            </Tooltip>
+          <Tooltip title="Download config file">
+            <IconButton onClick={() => this.handleDownload(pipeline.get('id'))}>
+              <DownloadIcon />
+            </IconButton>
+          </Tooltip>
 
-            <Tooltip title="Delete">
-              <IconButton onClick={() => this.props.onDelete(pipeline.get('id'))}>
-                <DeleteIcon />
-              </IconButton>
-            </Tooltip>
+          <Tooltip title="Delete">
+            <IconButton onClick={() => this.props.onDelete(pipeline.get('id'))}>
+              <DeleteIcon />
+            </IconButton>
+          </Tooltip>
 
-          </CardActions>
-        </Card>
-      )
-    };
-  }
-}
-
-/** A row to indicate s broad pipeline step on a pipeline card */
-class PipelineStep extends Component {
-  static propTypes = {
-    /** Whether the step is On in the pipeline configuration */
-    stepKey: PropTypes.bool.isRequired,
-    /** Text to display for step */
-    label: PropTypes.string,
-    /** Inherited style */
-    classes: PropTypes.object
-  }
-
-  render() {
-    const { stepKey, label, classes } = this.props;
-    const enabledStyle = {root: stepKey ? classes.featEnabled : classes.featDisabled};
-    return (
-      <ListItem key={`step-${label}`}>
-        <ListItemIcon>
-          <PipelineStepIcon classes={enabledStyle} />
-        </ListItemIcon>
-        <ListItemText classes={enabledStyle} primary={label} />
-      </ListItem>
-    )
+        </CardActions>
+      </Card>
+    );
   }
 }
 

--- a/app/components/PipelineStep.jsx
+++ b/app/components/PipelineStep.jsx
@@ -1,0 +1,32 @@
+/** A row to indicate a broad pipeline step on a pipeline card */
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+
+import { ListItem, ListItemIcon, ListItemText } from '@material-ui/core';
+import { PipelineStepIcon } from './icons';
+
+class PipelineStep extends Component {
+  static propTypes = {
+    /** Whether the step is On in the pipeline configuration */
+    stepKey: PropTypes.bool.isRequired,
+    /** Text to display for step */
+    label: PropTypes.string,
+    /** Inherited style */
+    classes: PropTypes.object
+  }
+
+  render() {
+    const { stepKey, label, classes } = this.props;
+    const enabledStyle = {root: stepKey ? classes.featEnabled : classes.featDisabled};
+    return (
+      <ListItem key={`step-${label}`}>
+        <ListItemIcon>
+          <PipelineStepIcon classes={enabledStyle} />
+        </ListItemIcon>
+        <ListItemText classes={enabledStyle} primary={label} />
+      </ListItem>
+    );
+  }
+}
+
+export default PipelineStep;


### PR DESCRIPTION
<!-- If you'd like use an emoji in the PR title, consider checking https://gitmoji.dev for guidance on emoji selection. Clicking an emoji image on that page will copy it to your clipboard. -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- The square brackets in the template represent something for you to replace. For example, you might change "Fixes #[issue number]" to "Fixes #1". -->
Fixes #150 by @shnizzedy, @tergeorge & @zeosmar

## Description
<!-- Concisely describe what the pull request does. -->
The GUI checks the version of a loaded participant pipeline config to determine how to handle (≥ 1.8.0 are handled differently from 1.5.0 ‒ < 1.8.0); [a <span title="continuous integration">CI</span> bug](https://github.com/FCP-INDI/C-PAC/issues/1763) prevented the version from being updated from development-version to production-version, and the version comparison was crashing with `.dev` suffixing the <span title="semantic version">semver</span>.

I already [pushed this change](https://github.com/FCP-INDI/C-PAC_GUI/commit/5ad6968d6b024191e6426253ee81e464b0f2ba88) to [`main`](https://github.com/FCP-INDI/C-PAC_GUI/tree/main) as a hotfix since the GUI was unusable while both #150 and https://github.com/FCP-INDI/C-PAC/issues/1763 were unresolved.

## Technical details
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->
### Diagnosis
I ran [the production code](https://github.com/FCP-INDI/C-PAC_GUI/tree/2eadc9f45ff18ddf0d8bfc065da29f7194121647) locally

```BASH
$ cd C-PAC_GUI
$ git fetch origin
$ git checkout 2eadc9f4
$ yarn run clean:all
$ yarn
$ yarn run dev:browser
```

and opened http://localhost:1212 in a browser with development tools open, so I could trace the error and test resolution attempts quickly.

Lots of errors showed up in the console on load, but the first meaningful one was
![`Uncaught TypeError: Invalid Version: 1.8.4.dev	semver.js?8d61`](https://user-images.githubusercontent.com/5974438/187706230-df0218d7-eeda-4ef2-a549-e4278af6d07e.png)

After c836b5460bf36eb7f3dfc6198193b5b9739e6cd1, that error and all downstream errors are gone!

### The code changes that resolve the issue
https://github.com/FCP-INDI/C-PAC_GUI/blob/c836b5460bf36eb7f3dfc6198193b5b9739e6cd1/app/components/PipelineCard.jsx#L42-L44
https://github.com/FCP-INDI/C-PAC_GUI/blob/c836b5460bf36eb7f3dfc6198193b5b9739e6cd1/app/components/PipelineCard.jsx#L152
### Root cause
[FCP-INDI/CPAC: Actions: Check updated version #271](https://github.com/FCP-INDI/C-PAC/runs/7025355425?check_suite_focus=true) failed

```BASH
[develop a4a0e00] :bookmark: Update version to 1.8.4 (🐛 RBC updates: Switch to MNI2006 templates & CBIG's Schaefer; fix XCP-QC 'final' values (#1737))
 46 files changed, 46 insertions(+), 46 deletions(-)
remote: error: GH006: Protected branch update failed for refs/heads/develop.        
remote: error: At least 1 approving review is required by reviewers with write access.        
To https://github.com/FCP-INDI/C-PAC
 ! [remote rejected] HEAD -> develop (protected branch hook declined)
error: failed to push some refs to 'https://github.com/FCP-INDI/C-PAC'
```

to push the updated version to the config files but reported success [![✔ ✔](https://user-images.githubusercontent.com/5974438/187700640-1d35082a-7386-49f6-a304-ddf97f3e0db0.png)](https://github.com/FCP-INDI/C-PAC/runs/7025355425?check_suite_focus=true); the unupdated version (`1.8.4.dev` instead of `1.8.4`) went unnoticed until [this bug](#150) was brought to our attention.



## Screenshots
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->
### Before
![Something went wrong!](https://user-images.githubusercontent.com/5974438/187533504-9c3bf68d-e015-478e-bef7-933758e2464f.png)
### After
![Default C-PAC 1.8.4.dev](https://user-images.githubusercontent.com/5974438/187694245-3cbfb09c-7f6a-43df-94cf-1ba9d0f86bfb.png)


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
